### PR TITLE
Add support for text/vCard and text/vCalendar MIME type

### DIFF
--- a/src/android/support/v7/mms/pdu/ContentType.java
+++ b/src/android/support/v7/mms/pdu/ContentType.java
@@ -30,8 +30,10 @@ public class ContentType {
 
     public static final String TEXT_PLAIN        = "text/plain";
     public static final String TEXT_HTML         = "text/html";
-    public static final String TEXT_VCALENDAR    = "text/x-vCalendar";
-    public static final String TEXT_VCARD        = "text/x-vCard";
+    public static final String TEXT_VCALENDAR    = "text/vCalendar";
+    public static final String TEXT_VCARD        = "text/vCard";
+    public static final String TEXT_X_VCALENDAR  = "text/x-vCalendar";
+    public static final String TEXT_X_VCARD      = "text/x-vCard";
 
     public static final String IMAGE_UNSPECIFIED = "image/*";
     public static final String IMAGE_JPEG        = "image/jpeg";
@@ -85,6 +87,8 @@ public class ContentType {
         sSupportedContentTypes.add(TEXT_HTML);
         sSupportedContentTypes.add(TEXT_VCALENDAR);
         sSupportedContentTypes.add(TEXT_VCARD);
+        sSupportedContentTypes.add(TEXT_X_VCALENDAR);
+        sSupportedContentTypes.add(TEXT_X_VCARD);
 
         sSupportedContentTypes.add(IMAGE_JPEG);
         sSupportedContentTypes.add(IMAGE_GIF);

--- a/src/com/android/messaging/mmslib/pdu/PduPersister.java
+++ b/src/com/android/messaging/mmslib/pdu/PduPersister.java
@@ -800,7 +800,7 @@ public class PduPersister {
                 // reliable.
                 final String encodedDataString = new EncodedStringValue(charset, data).getString();
                 if (encodedDataString != null && encodedDataString.startsWith(BEGIN_VCARD)) {
-                    contentType = ContentType.TEXT_VCARD;
+                    contentType = ContentType.TEXT_X_VCARD;
                     part.setContentType(contentType.getBytes());
                     if (LogUtil.isLoggable(TAG, LogUtil.DEBUG)) {
                         LogUtil.d(TAG, "PduPersister.persistPart part: " + uri + " contentType: " +

--- a/src/com/android/messaging/ui/UIIntentsImpl.java
+++ b/src/com/android/messaging/ui/UIIntentsImpl.java
@@ -301,7 +301,7 @@ public class UIIntentsImpl extends UIIntents {
         Assert.isTrue(MediaScratchFileProvider.isMediaScratchSpaceUri(vcardUri));
         final Intent intent = new Intent();
         intent.setAction(Intent.ACTION_VIEW);
-        intent.setDataAndType(vcardUri, ContentType.TEXT_VCARD.toLowerCase());
+        intent.setDataAndType(vcardUri, ContentType.TEXT_X_VCARD.toLowerCase());
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         startExternalActivity(context, intent);
     }

--- a/src/com/android/messaging/ui/mediapicker/ContactMediaChooser.java
+++ b/src/com/android/messaging/ui/mediapicker/ContactMediaChooser.java
@@ -133,7 +133,7 @@ class ContactMediaChooser extends MediaChooser {
                         public void run() {
                             final PendingAttachmentData pendingItem =
                                     PendingAttachmentData.createPendingAttachmentData(
-                                            ContentType.TEXT_VCARD.toLowerCase(), vCardUri);
+                                            ContentType.TEXT_X_VCARD.toLowerCase(), vCardUri);
                             mMediaPicker.dispatchPendingItemAdded(pendingItem);
                         }
                     });

--- a/src/com/android/messaging/util/ContentType.java
+++ b/src/com/android/messaging/util/ContentType.java
@@ -43,8 +43,10 @@ public final class ContentType {
 
     public static final String TEXT_PLAIN        = "text/plain";
     public static final String TEXT_HTML         = "text/html";
-    public static final String TEXT_VCALENDAR    = "text/x-vCalendar";
-    public static final String TEXT_VCARD        = "text/x-vCard";
+    public static final String TEXT_VCALENDAR    = "text/vCalendar";
+    public static final String TEXT_VCARD        = "text/vCard";
+    public static final String TEXT_X_VCALENDAR  = "text/x-vCalendar";
+    public static final String TEXT_X_VCARD      = "text/x-vCard";
 
     public static final String IMAGE_PREFIX      = "image/";
     public static final String IMAGE_UNSPECIFIED = "image/*";
@@ -128,7 +130,9 @@ public final class ContentType {
     }
 
     public static boolean isVCardType(final String contentType) {
-        return (null != contentType) && contentType.equalsIgnoreCase(TEXT_VCARD);
+        return (null != contentType)
+                && (contentType.equalsIgnoreCase(TEXT_X_VCARD)
+                        || contentType.equalsIgnoreCase(TEXT_VCARD));
     }
 
     public static boolean isDrmType(final String contentType) {


### PR DESCRIPTION
A vcf file can alias to both "text/vCard" and "text/x-vCard" MIME
types and an ics file can alias to "text/vCalendar" as well as
"text/x-vCalendar". However, if LineageOS does not get the "x-"
MIME type, it will incorrectly display an empty MMS.

Change-Id: I0b63767092c0e7422ff3592983d94b903d9e8cc5