### PR TITLE
add check before casting

### DIFF
--- a/src/com/android/messaging/ui/conversationlist/ForwardMessageActivity.java
+++ b/src/com/android/messaging/ui/conversationlist/ForwardMessageActivity.java
@@ -46,7 +46,9 @@ public class ForwardMessageActivity extends BaseBugleActivity
 
     @Override
     public void onAttachFragment(final Fragment fragment) {
-        Assert.isTrue(fragment instanceof ConversationListFragment);
+        if (!(fragment instanceof ConversationListFragment)) {
+            return;
+        }
         final ConversationListFragment clf = (ConversationListFragment) fragment;
         clf.setHost(this);
     }


### PR DESCRIPTION
casting `fragment` to `ConversationListFragment` is causing ClassCastException at onAttachFragment